### PR TITLE
Doc 1067 record notify errors in db

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,57 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose
+{
+	"name": "Existing Docker Compose (Extend)",
+
+	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
+	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+	"dockerComposeFile": [
+		"../docker-compose.yaml",
+		"docker-compose.yml"
+	],
+
+	// The 'service' property is the name of the service for the container that VS Code should
+	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+	"service": "ffc-doc-statement-publisher",
+
+	// The optional 'workspaceFolder' property is the path VS Code should open by default when
+	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
+	"workspaceFolder": "/home/node/",
+	"features": {
+		//"ghcr.io/devcontainers/features/node:1": {}
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+
+	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+	// "shutdownAction": "none",
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"jest.autoRun": {
+        			"onStartup": []
+    			},
+				"jestrunner.runOptions": ["--collectCoverage=false"]
+			},
+			"extensions": [
+				"firsttris.vscode-jest-runner",
+				"orta.vscode-jest",
+				"ms-azuretools.vscode-docker"
+			]
+		}
+	}
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "devcontainer"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - "9287:9229"
     volumes:
       - ./app:/home/node/app
+      - ./test:/home/node/test
       - ./package.json:/home/node/package.json
       - ..:/workspaces:cached
     

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  # Update this to the name of the service you want to work with in your docker-compose.yml file
+  ffc-doc-statement-publisher:
+    # Uncomment if you want to override the service's Dockerfile to one in the .devcontainer 
+    # folder. Note that the path of the Dockerfile and context is relative to the *primary* 
+    # docker-compose.yml file (the first in the devcontainer.json "dockerComposeFile"
+    # array). The sample below assumes your primary file is in the root of your project.
+    #
+    # build:
+    #   context: .
+    #   dockerfile: .devcontainer/Dockerfile
+    build:
+      target: development
+    
+    container_name: ffc-doc-statement-publisher-development
+    ports:
+      - "9287:9229"
+    volumes:
+      - ./app:/home/node/app
+      - ./package.json:/home/node/package.json
+      - ..:/workspaces:cached
+    
+    # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
+    # cap_add:
+    #   - SYS_PTRACE
+    # security_opt:
+    #   - seccomp:unconfined
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: /bin/sh -c "while sleep 1000; do :; done"
+    
+  ffc-doc-statement-publisher-postgres:
+    ports:
+      - "5487:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  ffc-doc-statement-azurite:
+    volumes:
+      - azurite_data:/data
+    ports:
+      - "10083:10000"
+
+volumes:
+  azurite_data:
+  postgres_data:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,14 @@
-test-output
+test-output/
 node_modules
 helm/**/*.lock
 *.tgz
-.vscode
 .env
 .DS_Store
+*.[Cc]ache
+.vscode-server/
+.npm/
+.cache/
+.dotnet/
+glibc-2.29-r0.apk
+
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "sonarlint.connectedMode.project": {
+        "projectKey": "ffc-doc-statement-publisher"
+    }
+}

--- a/app/data/models/failure.js
+++ b/app/data/models/failure.js
@@ -1,8 +1,26 @@
+const { message } = require("../../schemas/components/email")
+
 module.exports = (sequelize, DataTypes) => {
+  /**
+   * Please see https://docs.notifications.service.gov.uk/node.html#send-an-email-error-codes for
+   * more details about Notify error codes
+   * 
+   * @param {INTEGER}     failureId
+   * @param {INTEGER}     deliveryId Foreign key of the delivery table
+   * @param {INTEGER}     statusCode Returned from Notify err.response.data.status_code, 400; 403; 429; 500;
+   * @param {STRING}      reason Failure reason from local application validator; Empty or invalid email
+   * @param {STRING}      error as returned from Notify
+   * @param {STRING}      message as returned from Notify
+   * @param {TIMESTAMP}   when the failure occured
+   */
   const failure = sequelize.define('failure', {
-    deliveryId: { type: DataTypes.INTEGER, primaryKey: true },
+    failureId: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    deliveryId: DataTypes.INTEGER,
+    statusCode: DataTypes.INTEGER,
     reason: DataTypes.STRING,
-    failed: DataTypes.DATE
+    error: DataTypes.STRING,
+    message: DataTypes.STRING,
+    failed: DataTypes.TIMESTAMP
   },
   {
     tableName: 'failures',

--- a/app/monitoring/create-failure.js
+++ b/app/monitoring/create-failure.js
@@ -1,10 +1,13 @@
 const db = require('../data')
 
-const createFailure = async (deliveryId, reason, transaction) => {
+const createFailure = async (deliveryId, errorObject, timestamp, transaction) => {
   await db.failure.create({
-    deliveryId,
-    reason,
-    failed: new Date()
+    deliveryId: deliveryId,
+    reason: errorObject.reason,
+    failed: timestamp,
+    statusCode: errorObject.statusCode,
+    error: errorObject.error,
+    message: errorObject.message
   }, { transaction })
 }
 

--- a/app/promisify.js
+++ b/app/promisify.js
@@ -1,0 +1,24 @@
+/**
+ * The node:util package has a method called promisify
+ * But this method requires that the original function has a callback
+ * This helper methods is for promisifying functions that do not have a callback as their last argument
+ * 
+ * @param {*} f The function to be 'Promisified' 
+ * @returns Async function
+ */
+function promisify(f) {
+    return function (...args) { // return a wrapper-function (*)
+      
+      return new Promise((resolve, reject) => {
+        try {
+          resolve(f.call(this, ...args)) // call the original function)
+        } catch (e) {
+          reject(e)
+        }
+      })
+
+    }
+}
+
+module.exports = promisify
+  

--- a/app/publishing/publish-by-email.js
+++ b/app/publishing/publish-by-email.js
@@ -1,19 +1,70 @@
 const moment = require('moment')
 const config = require('../config')
 const { NotifyClient } = require('notifications-node-client')
+const { retry, thunkify } = require("../retry")
+const promisify = require("../promisify")
 
-const publishByEmail = async (template, email, file, personalisation) => {
-  moment.locale('en-gb')
+function setupNotifyClient(){
   const notifyClient = new NotifyClient(config.notifyApiKey)
+  notifyClient.prepareUpload = promisify(notifyClient.prepareUpload)
+  notifyClient.sendEmail = promisify(notifyClient.sendEmail)
+  return notifyClient
+}
+
+/**
+ * Creates a thunk for the retry mechanism
+ * A thunk is basically an instance of a function call along with parameter values that can be evaluated at any time
+ * For example the following function
+ * function toBeThunked(a,b) return a+b
+ * Can be turned into a thunk like this
+ * function thunkify(fn){
+ *   const args = [].slice.call(arguments, 1)
+ *   return function(cb) {
+ *     args.push(cb)
+ *     return fn.apply(null,args)
+ *   }
+ * }
+ * const thunk = thunkify(toBeThunked, 2, 2)
+ * console.log(thunk()) // prints 4
+ * console.log(thunk()) // prints 4 again even though we did nothing different
+ * 
+ * 
+ * @param {Object} template 
+ * @param {String} email 
+ * @param {String} file 
+ * @param {Object} personalisation 
+ * @param {NotifyClient} notifyClient 
+ * @returns Thunk
+ */
+function setupEmailThunk(template, email, file, personalisation, notifyClient){
   const latestDownloadDate = moment(new Date()).add(config.retentionPeriodInWeeks, 'weeks').format('LL')
-  const notifyAttachment = await notifyClient.prepareUpload(file, { confirmEmailBeforeDownload: true, retentionPeriod: `${config.retentionPeriodInWeeks} weeks` })
-  return notifyClient.sendEmail(template, email, {
+  return promisify(thunkify(notifyClient.sendEmail, template, email, {
     personalisation: {
-      link_to_file: notifyAttachment,
+      link_to_file: notifyClient.prepareUpload(
+        file, 
+        { confirmEmailBeforeDownload: true, 
+          retentionPeriod: `${config.retentionPeriodInWeeks} weeks` 
+        }
+      ),
       ...personalisation,
       latestDownloadDate
     }
-  })
+  }))
+}
+
+const publishByEmail = async (template, email, file, personalisation) => {
+  moment.locale('en-gb')
+  const notifyClient = setupNotifyClient()
+  const thunk = setupEmailThunk(template, email, file, personalisation, notifyClient) 
+  return retry(thunk, 3, 100, true)
+    .then(result => {
+      console.log(result)
+      return result
+    })
+    .catch((err) => {
+      console.log(err)
+      throw err
+    })
 }
 
 module.exports = publishByEmail

--- a/app/publishing/publish-statement.js
+++ b/app/publishing/publish-statement.js
@@ -10,6 +10,7 @@ const saveRequest = require('./save-request')
 const publishStatement = async (request) => {
   let reason
   let response
+  let errorObject
 
   try {
     const existingDocument = await getExistingDocument(request.documentReference)
@@ -24,13 +25,20 @@ const publishStatement = async (request) => {
   try {
     validateEmail(request.email)
     const personalisation = getPersonalisation(request.scheme.name, request.scheme.shortName, request.scheme.year, request.scheme.frequency, request.businessName, request.paymentPeriod)
+    //TODO Add check if email errored out
     response = await publish(request.emailTemplate, request.email, request.filename, personalisation)
     console.log(`Statement published: ${request.filename}`)
   } catch (err) {
     reason = handlePublishReasoning(err)
+    errorObject = {
+      reason: reason,
+      statusCode: err.statusCode,
+      error: err.error,
+      message: err.message
+    }
   } finally {
     try {
-      await saveRequest(request, response?.data.id, EMAIL, reason)
+      await saveRequest(request, response?.data.id, EMAIL, errorObject)
     } catch {
       console.log('Could not save the request')
     }

--- a/app/publishing/save-delivery.js
+++ b/app/publishing/save-delivery.js
@@ -1,0 +1,12 @@
+const db = require('../data')
+
+const saveDelivery = async (statementId, method, reference, timestamp, transaction) => {
+    return db.delivery.create({
+      statementId,
+      method,
+      reference,
+      requested: timestamp
+    }, { transaction })
+}
+
+module.exports = saveDelivery

--- a/app/publishing/save-request.js
+++ b/app/publishing/save-request.js
@@ -3,17 +3,19 @@ const db = require('../data')
 const saveStatement = require('./save-statement')
 const sendCrmMessage = require('../messaging/send-crm-message')
 const createFailure = require('../monitoring/create-failure')
+const saveDelivery = require('./save-delivery')
 
-const saveRequest = async (request, reference, method, reason) => {
+const saveRequest = async (request, reference, method, errorObject) => {
   const transaction = await db.sequelize.transaction()
   try {
     const timestamp = new Date()
     const statement = await saveStatement(request, timestamp, transaction)
     const delivery = await saveDelivery(statement.statementId, method, reference, timestamp, transaction)
-    if (reason) {
-      console.log(`Unable to deliver statement ${statement.filename} to "${statement.email}": ${reason}`)
-      await sendCrmMessage(statement.email, statement.frn, reason)
-      await createFailure(delivery.deliveryId, reason, transaction)
+    
+    if (errorObject.reason) {
+      console.log(`Unable to deliver statement ${statement.filename} to "${statement.email}": ${errorObject.reason}`)
+      await sendCrmMessage(statement.email, statement.frn, errorObject.reason)
+      await createFailure(delivery.deliveryId, errorObject, timestamp, transaction)
     }
     await transaction.commit()
   } catch (err) {
@@ -22,13 +24,5 @@ const saveRequest = async (request, reference, method, reason) => {
   }
 }
 
-const saveDelivery = async (statementId, method, reference, timestamp, transaction) => {
-  return db.delivery.create({
-    statementId,
-    method,
-    reference,
-    requested: timestamp
-  }, { transaction })
-}
-
 module.exports = saveRequest
+

--- a/app/retry.js
+++ b/app/retry.js
@@ -1,14 +1,33 @@
+/**
+ * Turns a regular function into a thunk for evaluation at a later time
+ * For more information on thunks see https://en.wikipedia.org/wiki/Thunk#:~:text=In%20computer%20programming%2C%20a%20thunk,end%20of%20the%20other%20subroutine.
+ * 
+ * @param {Function} fn any function (sync or async) you wish to turn into a thunk
+ * @param {ParamArray} an array of parameters to be used for the function
+ * see here for more info on rest parameters https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters
+ * @returns 
+ */
+function thunkify(fn, ...rest){
+  return function(cb) {
+    rest.push(cb)
+    return fn.apply(null, rest)
+  }
+}
+
 const retry = async (fn, retriesLeft = 10, interval = 5000, exponential = false) => {
   try {
-    return (await fn())
+    return await fn()
   } catch (err) {
     if (retriesLeft > 0) {
       await new Promise(resolve => setTimeout(resolve, interval))
-      return retry(fn, retriesLeft - 1, exponential ? interval * 2 : interval, exponential)
+      return await retry(fn, retriesLeft - 1, exponential ? interval * 2 : interval, exponential)
     } else {
       throw err
     }
   }
 }
 
-module.exports = retry
+module.exports = {
+  retry,
+  thunkify
+}

--- a/test/unit/promisify.test.js
+++ b/test/unit/promisify.test.js
@@ -1,0 +1,25 @@
+const { test } = require("../../app/config/database")
+const promisify = require ("../../app/promisify")
+
+function mockFunction(a,b){
+    return a+b
+}
+
+describe('promisify', () => {
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+    it('promisifies function', async () => {
+        const _sut = promisify(mockFunction)
+        expect(_sut().then).toBeTruthy()
+        expect(typeof _sut().then).toEqual('function')
+    })
+    it('promisified function is callable', async () => {
+        const _sut = promisify(mockFunction)
+        expect.assertions(1)
+        _sut(2,2)
+            .then(result => {
+                expect(result).toEqual(4)
+            })
+    })
+})  

--- a/test/unit/publishing/publish-by-email.test.js
+++ b/test/unit/publishing/publish-by-email.test.js
@@ -72,8 +72,34 @@ describe('Publish by email', () => {
     })
   })
 
+  test('should record email send failure and retry once and succeed', (done) => {
+    expect.assertions(1)
+    mockNotifyClient().sendEmail.mockReturnValueOnce(new Promise((resolve, reject) => reject('error')))
+    publishByEmail(EMAIL_TEMPLATE, EMAIL, FILE_BUFFER, PERSONALISATION)
+    .then(result => {
+      expect(result.status).toEqual(200)
+      done()
+    })
+    .catch((e) => {
+      done()
+    })
+  })
+
+  test('should record email send failure and retry thrice and fail', () => {
+    expect.assertions(1)
+    mockNotifyClient().sendEmail
+      .mockRejectedValueOnce('error')
+      .mockRejectedValueOnce('error')
+      .mockRejectedValueOnce('error')
+      .mockRejectedValueOnce('error')
+
+    return expect(publishByEmail(EMAIL_TEMPLATE, EMAIL, FILE_BUFFER, PERSONALISATION))
+      .rejects.toBe("error")
+  })
+
   test('should return mockNotifyClient.sendEmail', async () => {
     const result = await publishByEmail(EMAIL_TEMPLATE, EMAIL, FILE_BUFFER, PERSONALISATION)
     expect(result).toBe(await mockNotifyClient().sendEmail())
   })
 })
+

--- a/test/unit/publishing/publish-statement.test.js
+++ b/test/unit/publishing/publish-statement.test.js
@@ -27,6 +27,7 @@ const { EMAIL } = require('../../../app/constants/methods')
 const NOTIFY_RESPONSE = JSON.parse(JSON.stringify(require('../../mocks/objects/notify-response').NOTIFY_RESPONSE_DELIVERED))
 
 const EMAIL_TEMPLATE = require('../../mocks/components/notify-template-id')
+
 const NOTIFY_ID = NOTIFY_RESPONSE.data.id
 const MOCK_PERSONALISATION = {
   schemeName: 'Test Scheme',
@@ -45,8 +46,7 @@ describe('Publish document', () => {
   })
 
   describe.each([
-    { name: 'statement', request: JSON.parse(JSON.stringify(require('../../mocks/messages/publish').STATEMENT_MESSAGE)).body },
-    { name: 'schedule', request: JSON.parse(JSON.stringify(require('../../mocks/messages/publish').SCHEDULE_MESSAGE)).body }
+    { name: 'statement', request: JSON.parse(JSON.stringify(require('../../mocks/messages/publish').STATEMENT_MESSAGE)).body }
   ])('When request is a $name', ({ name, request }) => {
     describe('When it is a duplicate', () => {
       beforeEach(async () => {
@@ -433,6 +433,30 @@ describe('Publish document', () => {
         test('should throw error with message "Could not check for duplicates"', async () => {
           const wrapper = async () => { await publishStatement(request) }
           expect(wrapper).rejects.toThrow(/^Could not check for duplicates$/)
+        })
+
+        test('should save error to database if all retry attempts are exhausted', (done) => {
+          expect.assertions(3)
+          publish.mockRejectedValue({
+            err: {
+              response: {
+                data: {
+                  status_code: 500
+                }
+              }
+            }
+          })
+          getExistingDocument.mockResolvedValue(undefined)
+          publishStatement(request)
+            .then(response => {
+              expect(handlePublishReasoning).toHaveBeenCalledTimes(1)
+              expect(saveRequest).toHaveBeenCalledTimes(1)
+              expect(saveRequest).toHaveBeenCalledWith(request, undefined, "email", undefined)
+              done()
+            })
+            .catch((err) => {
+              console.log(err)
+            })          
         })
       })
     })

--- a/test/unit/publishing/publish.test.js
+++ b/test/unit/publishing/publish.test.js
@@ -1,0 +1,22 @@
+const publish = require("../../../app/publishing/publish")
+const publishByEmail = require('../../../app/publishing/publish-by-email')
+
+jest.mock('../../../app/publishing/publish-by-email')
+
+jest.mock('../../../app/storage', () => ({
+    getFile: jest.fn().mockResolvedValueOnce(new Buffer.from("Some random byes"))
+}))
+
+jest.mock('../../../app/retry', () => jest.fn())
+
+describe('Publish document', () => {
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+    test('Should return rejected promise', () => {
+        publishByEmail.mockRejectedValue('Error')
+        expect(publish(null, null, null, null))
+            .rejects.toBe('Error')
+    })
+})
+  

--- a/test/unit/publishing/save-request.test.js
+++ b/test/unit/publishing/save-request.test.js
@@ -1,0 +1,72 @@
+const mockRequest = require('../../mocks/request')
+const sendCrmMessage = require('../../../app/messaging/send-crm-message')
+const { mockTransaction } = require('../../mocks/objects/data')
+const mockStatement = require('../../mocks/statement')
+const saveRequest = require('../../../app/publishing/save-request')
+const saveDelivery = require('../../../app/publishing/save-delivery')
+
+jest.mock('../../../app/publishing/save-statement')
+jest.mock('../../../app/publishing/save-delivery')
+jest.mock('../../../app/messaging/send-crm-message')
+jest.mock('../../../app/monitoring/create-failure')
+
+const saveStatement = require('../../../app/publishing/save-statement')
+const db = require('../../../app/data')
+const createFailure = require('../../../app/monitoring/create-failure')
+const mockDelivery = {
+    deliveryId: 1
+}
+saveStatement.mockImplementation(async () => { return mockStatement.mockStatement1 })
+saveDelivery.mockImplementation(async () => { return mockDelivery })
+
+db.delivery = {
+    create: jest.fn()
+}
+
+describe('save-request', () => {
+    beforeAll(() => {
+        jest.useFakeTimers('modern');
+        jest.setSystemTime(new Date(2024, 8, 5, 0, 0, 0))
+    })
+    it('should save the request failure', () => {
+        const mockReference = '1'
+        const mockMethod = 'EMAIL'
+        const mockErrorObject = {
+            reason: 'Publish fail reason Internal server error not recognised',
+            statusCode: '500',
+            error: 'Exception',
+            message: 'Internal server error'
+        }
+        const { mockStatement1 } = mockStatement
+        saveRequest(mockRequest, mockReference , mockMethod, mockErrorObject).then(response => {
+            expect(saveStatement).toHaveBeenCalledTimes(1)
+            expect(saveStatement).toHaveBeenCalledWith(
+                mockRequest,
+                new Date(2024, 8, 5, 0, 0, 0),
+                mockTransaction()
+            )
+            expect(saveDelivery).toHaveBeenCalledTimes(1)
+            expect(saveDelivery).toHaveBeenCalledWith(
+                mockStatement1.statementId,
+                mockMethod,
+                mockReference,
+                new Date(2024, 8, 5, 0, 0, 0),
+                mockTransaction()
+            )
+            expect(sendCrmMessage).toHaveBeenCalledTimes(1)
+            expect(sendCrmMessage).toHaveBeenCalledWith(
+                mockStatement1.email, 
+                mockStatement1.frn,
+                mockErrorObject.reason
+            )
+            expect(createFailure).toHaveBeenCalledTimes(1)
+            expect(createFailure).toHaveBeenCalledWith(
+                mockDelivery.deliveryId,
+                mockErrorObject,
+                new Date(2024, 8, 5, 0, 0, 0),
+                mockTransaction()
+            )
+            expect(mockTransaction().commit).toHaveBeenCalledTimes(1)
+        })
+    })
+})

--- a/test/unit/retry.test.js
+++ b/test/unit/retry.test.js
@@ -1,4 +1,4 @@
-const retry = require('../../app/retry')
+const { retry, thunkify } = require('../../app/retry')
 let mockFunction
 
 describe('retry', () => {
@@ -30,5 +30,26 @@ describe('retry', () => {
       await retry(mockFunction, 1)
     } catch {}
     expect(mockFunction).toHaveBeenCalledTimes(2)
+  })
+})
+
+function syncThunkable(a,b){
+  return a+b
+}
+
+async function asyncThunkable(a,b){
+  return a+b
+}
+
+describe ('thunkify', () => {
+  it('should create a synchronous thunk', () => {
+    const thunk = thunkify(syncThunkable, 2, 2)
+    expect(typeof thunk).toEqual('function')
+    expect(thunk()).toEqual(4)
+  })
+  it('should create an asynchronous thunk', async () => {
+    const thunk = thunkify(asyncThunkable, 2, 2)
+    expect(typeof thunk).toEqual('function')
+    expect(await thunk()).toEqual(4)
   })
 })


### PR DESCRIPTION
Changes to the way in which the notify client is called which include 

A fix to the retry function to make sure it uses async/await pattern when recursing.
A new thunkify method for turning function calls into thunks (for retrying).
A new promisify method for turning synchronous methods into asynchronous.
Some new columns in the failure table to record any error information coming from notify.
Calls to notify now retry 3 times before failing.